### PR TITLE
Fix TypeError: NoneType object is not iterable

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -16,7 +16,7 @@ def get_headless_endpoint_ips(headless_svc, namespace):
 
     if headless_svc_eps.items[0].subsets is not None:
         for subset in headless_svc_eps.items[0].subsets:
-            if subset is not None:
+            if subset is not None and subset.addresses is not None:
                 for address in subset.addresses:
                     headless_eps_ips.append(address.ip)
 

--- a/app/services.py
+++ b/app/services.py
@@ -16,8 +16,9 @@ def get_headless_endpoint_ips(headless_svc, namespace):
 
     if headless_svc_eps.items[0].subsets is not None:
         for subset in headless_svc_eps.items[0].subsets:
-            for address in subset.addresses:
-                headless_eps_ips.append(address.ip)
+            if subset is not None:
+                for address in subset.addresses:
+                    headless_eps_ips.append(address.ip)
 
     return sorted(headless_eps_ips)
 


### PR DESCRIPTION
When target service is crashlooping, the dns check will error out with something similar to this:

```
Getting the endpoint IPs for headless service: 'mix-dialog-command' in namespace: 'mix-prod'
Traceback (most recent call last):
  File "main.py", line 69, in <module>
    resolve_service(
  File "/services.py", line 48, in resolve_service
    comparison_ips = get_headless_endpoint_ips(service, namespace)
  File "/services.py", line 19, in get_headless_endpoint_ips
    for address in subset.addresses:
TypeError: 'NoneType' object is not iterable
```

Seems like checking if subset and its addresses are not None should be enough to avoid it erroring out.